### PR TITLE
Make trailing whitespace optional in branch parser

### DIFF
--- a/src/Repository.php
+++ b/src/Repository.php
@@ -89,7 +89,7 @@ class Repository implements Contracts\SiteRepository
                     Log::debug($branch);
 
                     // Parse the branch data for the different parts
-                    preg_match('/^[\s|\*]?\s?(?<name>.*?)\s+(?<commit>[0-9A-f]{6,})\s\[?(?(?<=\[)(?<tracking>.*?)\:?|.*)\]?\s/', $branch, $matches);
+                    preg_match('/^[\s|\*]?\s?(?<name>.*?)\s+(?<commit>[0-9A-f]{6,})\s\[?(?(?<=\[)(?<tracking>.*?)\:?|.*)\]?\s?/', $branch, $matches);
 
                     return [
                         'current' => Str::startsWith($branch, '*'),


### PR DESCRIPTION
I'm not sure what the difference is on my system (I'm on Git 2.30.1 if it matters), but the current regex didn't work for me. It found no matches, which caused an `Undefined array key "name"` error.

For me, the problem was the trailing whitespace. If I removed it, it works.

This PR makes the trailing whitespace optional.﻿
