### PR TITLE
Add action listing route

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -11,5 +11,6 @@ Route::group(['prefix' => 'gitamic/api'], function () {
     Route::post('push', 'GitamicApiController@push');
     Route::post('pull', 'GitamicApiController@pull');
     Route::get('actions/{type}', 'GitamicApiController@actions');
+    Route::post('actions/{type}/list', 'GitamicApiController@actions');
     Route::post('actions/{type}', 'GitamicApiController@doAction');
 });


### PR DESCRIPTION
This PR adds a separate POST route for getting the bulk action listing, which will be required for Statamic 3.1.22 (see https://github.com/statamic/cms/pull/3298).

I noticed that the problem https://github.com/statamic/cms/pull/3298 was fixing was easy to run into on Gitamic. If you have a lot of unstaged files (I had about 300 when I tried) and you click the toggle-all checkbox, it would fail.

I've left the existing `Route::get('actions/{type}'` there so it'll continue to work for 3.1.21 and lower.

If you'd rather, you could bump the `statamic/cms` requirement to `^3.1.22` and remove the `Route::get('actions/{type}` route.